### PR TITLE
EDISUP-19351: follow and process redirect for fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.9 - 2025.01.27
+- Follow and processing the status of the redirect code (302) for the fetch method
+
 ## v1.8 - 2024.05.21
 - Update react-ui
 - Add mini modals

--- a/db-viewer-ui/src/Domain/ApiBase/ApiBase.ts
+++ b/db-viewer-ui/src/Domain/ApiBase/ApiBase.ts
@@ -22,6 +22,7 @@ export default class ApiBase {
             ["Content-Type"]: "application/json",
         },
         ["credentials"]: "same-origin",
+        redirect: "follow",
     };
     public prefix: string;
 
@@ -58,11 +59,15 @@ export default class ApiBase {
             method: "POST",
             body: JSON.stringify(body),
         });
+
         await this.checkStatus(response);
+        this.processRedirect(response);
+
         const textResult = await response.text();
         if (textResult !== "") {
             return JSON.parse(textResult);
         }
+
         return undefined;
     }
 
@@ -107,9 +112,11 @@ export default class ApiBase {
             ...ApiBase.additionalHeaders,
             method: "GET",
         });
+
         await this.checkStatus(response);
-        const result = await response.json();
-        return result;
+        this.processRedirect(response);
+
+        return response.json();
     }
 
     public async delete(url: string, body: {}): Promise<any> {
@@ -118,11 +125,21 @@ export default class ApiBase {
             method: "DELETE",
             body: JSON.stringify(body),
         });
+
         await this.checkStatus(response);
+        this.processRedirect(response);
+
         const textResult = await response.text();
         if (textResult !== "") {
             return JSON.parse(textResult);
         }
+
         return undefined;
+    }
+
+    private processRedirect(response: Response): void {
+        if (response.redirected && response.url) {
+            location.href = response.url;
+        }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8",
+  "version": "1.9",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
[EDISUP-19351](https://edo-yt.skbkontur.ru/issue/EDISUP-19351/Oshibka-v-adminke-kogda-servis-lezhit).

**Существующая проблема:**
При недоступности API-сервиса, обслуживающего запросы для db-viewer-а, приложение не может обработать ответ с кодом 302 (Redirect). После детального анализа было выявлено, что метод `fetch` по-умолчанию не обрабатывает такие ответы - это нужно сделать самостоятельно, применив специальную политику. Информацию по данной проблеме можно также найти[ здесь](https://stackoverflow.com/questions/39735496/redirect-after-a-fetch-post-call). В [комментариях](https://stackoverflow.com/a/39739894) к "правильному" ответу можно получить доп. информацию о возможных вариантах решения.

**Решение**:
Было решено просто дополнительно обрабатывать ответ на наличие значения `true` в свойстве [`redirected`](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected).