### PR TITLE
Fix scrollTo in ObjectTable

### DIFF
--- a/db-viewer-ui/src/Components/ObjectTable/ObjectTable.tsx
+++ b/db-viewer-ui/src/Components/ObjectTable/ObjectTable.tsx
@@ -42,7 +42,9 @@ export function ObjectTable({
     const [showConfirmModal, setShowConfirmModal] = useState(false);
     const [deletedIndex, setDeletedIndex] = useState<number | null>(null);
     const theme = useContext(ThemeContext);
-    useEffect(() => window.scrollTo(0, 0), [items]);
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [items]);
 
     const handleDeleteItem = () => {
         if (deletedIndex != null) {


### PR DESCRIPTION
Chrome 150 changed programmatic scroll APIs (window.scrollTo) to return a Promise.
With an implicit-return arrow function in useEffect, React may treat that return value as an invalid cleanup function

**What changed**
Update ObjectTable.tsx:
from: `useEffect(() => window.scrollTo(0, 0), [items]);`
to: `useEffect(() => {
window.scrollTo(0, 0);
}, [items]);`